### PR TITLE
feat(#5): program grammar

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ log = { version = "0.4.21", features = [] }
 hamcrest = "0.1.5"
 pest = "2.7.13"
 pest_derive = "2.7.13"
+parameterized = "2.0.0"
 
 [lints.rust]
 missing_docs = "deny"

--- a/src/parser/fsl_parser.rs
+++ b/src/parser/fsl_parser.rs
@@ -48,4 +48,12 @@ mod tests {
         assert_that!(parsed.as_str(), is(equal_to("+repo me/foo > foo")));
         Ok(())
     }
+    
+    #[test]
+    fn parses_object() -> Result<()> {
+        let parsed = FslParser::parse(Rule::object, "repo me/foo > foo")
+            .expect("Failed to parse FSL syntax");
+        assert_that!(parsed.as_str(), is(equal_to("repo me/foo > foo")));
+        Ok(())
+    }
 }

--- a/src/parser/fsl_parser.rs
+++ b/src/parser/fsl_parser.rs
@@ -40,4 +40,12 @@ mod tests {
         assert_that!(parse.as_str(), is(equal_to("me: @jeff")));
         Ok(())
     }
+
+    #[test]
+    fn parses_command() -> Result<()> {
+        let parsed = FslParser::parse(Rule::command, "+repo me/foo > foo")
+            .expect("Failed to parse FSL syntax");
+        assert_that!(parsed.as_str(), is(equal_to("+repo me/foo > foo")));
+        Ok(())
+    }
 }

--- a/src/parser/fsl_parser.rs
+++ b/src/parser/fsl_parser.rs
@@ -84,20 +84,22 @@ mod tests {
         Ok(())
     }
 
-    #[parameterized(input = {"@jeff", "@x", "@_f"})]
+    #[parameterized(input = {"@jeff", "@x"})]
     fn parses_login(input: &str) -> Result<()> {
         let parsed = FslParser::parse(Rule::login, input)
             .expect("Failed to parse login");
         assert_that!(parsed.as_str(), is(equal_to(input)));
         Ok(())
     }
-    
+
     #[should_panic(expected = "Failed to parse login")]
     #[parameterized(
         input = {
+            "@_f",
             "abc",
             "@",
-            "testing@"
+            "testing@",
+            "@."
         }
     )]
     fn panics_on_invalid_login(input: &str) {

--- a/src/parser/fsl_parser.rs
+++ b/src/parser/fsl_parser.rs
@@ -28,10 +28,10 @@ pub struct FslParser {}
 
 #[cfg(test)]
 mod tests {
-    use parameterized::parameterized;
     use crate::parser::fsl_parser::{FslParser, Rule};
     use anyhow::Result;
     use hamcrest::{equal_to, is, HamcrestMatcher};
+    use parameterized::parameterized;
     use pest::Parser;
 
     #[test]
@@ -91,10 +91,16 @@ mod tests {
         assert_that!(parsed.as_str(), is(equal_to(input)));
         Ok(())
     }
-
+    
     #[should_panic(expected = "Failed to parse login")]
-    #[test]
-    fn panics_on_empty_login() {
-        FslParser::parse(Rule::login, "@").expect("Failed to parse login");
+    #[parameterized(
+        input = {
+            "abc",
+            "@",
+            "testing@"
+        }
+    )]
+    fn panics_on_invalid_login(input: &str) {
+        FslParser::parse(Rule::login, input).expect("Failed to parse login");
     }
 }

--- a/src/parser/fsl_parser.rs
+++ b/src/parser/fsl_parser.rs
@@ -35,7 +35,8 @@ mod tests {
     use pest::Parser;
 
     #[test]
-    fn creates_parser() -> Result<()> {
+    // @todo #5:35min X.
+    fn parses_me() -> Result<()> {
         let parse = FslParser::parse(Rule::me, "me: @jeff")
             .expect("Failed to parse FSL syntax");
         assert_that!(parse.as_str(), is(equal_to("me: @jeff")));
@@ -73,6 +74,14 @@ mod tests {
         let parsed = FslParser::parse(Rule::object, "repo me/foo > foo")
             .expect("Failed to parse FSL syntax");
         assert_that!(parsed.as_str(), is(equal_to("repo me/foo > foo")));
+        Ok(())
+    }
+    
+    #[test]
+    fn parses_object_without_attributes() -> Result<()> {
+        let parsed = FslParser::parse(Rule::object, "repo > foo")
+            .expect("Failed to parse FSL syntax");
+        assert_that!(parsed.as_str(), is(equal_to("repo > foo")));
         Ok(())
     }
 

--- a/src/parser/fsl_parser.rs
+++ b/src/parser/fsl_parser.rs
@@ -36,14 +36,6 @@ mod tests {
 
     #[test]
     // @todo #5:35min X.
-    fn parses_me() -> Result<()> {
-        let parse = FslParser::parse(Rule::me, "me: @jeff")
-            .expect("Failed to parse FSL syntax");
-        assert_that!(parse.as_str(), is(equal_to("me: @jeff")));
-        Ok(())
-    }
-
-    #[test]
     fn parses_program() -> Result<()> {
         let parsed = FslParser::parse(
             Rule::program,
@@ -59,6 +51,36 @@ mod tests {
         //     is(equal_to("me: @jeff\n+repo me/foo > x\n+repo me/bar > y\n"))
         // );
         Ok(())
+    }
+
+    #[test]
+    fn parses_me() -> Result<()> {
+        let parse = FslParser::parse(Rule::me, "me: @jeff")
+            .expect("Failed to parse FSL syntax");
+        assert_that!(parse.as_str(), is(equal_to("me: @jeff")));
+        Ok(())
+    }
+
+    #[parameterized(input = {"@jeff", "@x"})]
+    fn parses_login(input: &str) -> Result<()> {
+        let parsed = FslParser::parse(Rule::login, input)
+            .expect("Failed to parse login");
+        assert_that!(parsed.as_str(), is(equal_to(input)));
+        Ok(())
+    }
+
+    #[should_panic(expected = "Failed to parse login")]
+    #[parameterized(
+        input = {
+            "@_f",
+            "abc",
+            "@",
+            "testing@",
+            "@."
+        }
+    )]
+    fn panics_on_invalid_login(input: &str) {
+        FslParser::parse(Rule::login, input).expect("Failed to parse login");
     }
 
     #[test]
@@ -91,27 +113,5 @@ mod tests {
             .expect("Failed to parse FSL syntax");
         assert_that!(parsed.as_str(), is(equal_to("> x")));
         Ok(())
-    }
-
-    #[parameterized(input = {"@jeff", "@x"})]
-    fn parses_login(input: &str) -> Result<()> {
-        let parsed = FslParser::parse(Rule::login, input)
-            .expect("Failed to parse login");
-        assert_that!(parsed.as_str(), is(equal_to(input)));
-        Ok(())
-    }
-
-    #[should_panic(expected = "Failed to parse login")]
-    #[parameterized(
-        input = {
-            "@_f",
-            "abc",
-            "@",
-            "testing@",
-            "@."
-        }
-    )]
-    fn panics_on_invalid_login(input: &str) {
-        FslParser::parse(Rule::login, input).expect("Failed to parse login");
     }
 }

--- a/src/parser/fsl_parser.rs
+++ b/src/parser/fsl_parser.rs
@@ -35,7 +35,9 @@ mod tests {
     use pest::Parser;
 
     #[test]
-    // @todo #5:35min X.
+    // @todo #5:35min Supply FSL programs from input files.
+    //  Instead of supplying FSL programs as strings here, we should read them
+    //  from `resources/snippets/`.
     fn parses_program() -> Result<()> {
         let parsed = FslParser::parse(
             Rule::program,
@@ -44,12 +46,11 @@ mod tests {
         .expect("Failed to parse FSL syntax")
         .next()
         .expect("Failed to get pair");
-        let pairs = parsed.into_inner();
-        print!("{}", pairs);
-        // assert_that!(
-        //     parsed.as_str(),
-        //     is(equal_to("me: @jeff\n+repo me/foo > x\n+repo me/bar > y\n"))
-        // );
+        let pairs = parsed.into_inner().as_str();
+        assert_that!(
+            pairs,
+            is(equal_to("me: @jeff\n+repo me/foo > x\n+repo me/bar > y"))
+        );
         Ok(())
     }
 
@@ -132,10 +133,12 @@ mod tests {
             "_",
             "_test",
             "@",
-            "."
+            ".",
+            "/t"
         }
     )]
     fn panics_on_invalid_ref(input: &str) {
-        FslParser::parse(Rule::reference, input).expect("Failed to parse reference");
+        FslParser::parse(Rule::reference, input)
+            .expect("Failed to parse reference");
     }
 }

--- a/src/parser/fsl_parser.rs
+++ b/src/parser/fsl_parser.rs
@@ -98,7 +98,7 @@ mod tests {
         assert_that!(parsed.as_str(), is(equal_to("repo me/foo > foo")));
         Ok(())
     }
-    
+
     #[test]
     fn parses_object_without_attributes() -> Result<()> {
         let parsed = FslParser::parse(Rule::object, "repo > foo")
@@ -113,5 +113,29 @@ mod tests {
             .expect("Failed to parse FSL syntax");
         assert_that!(parsed.as_str(), is(equal_to("> x")));
         Ok(())
+    }
+
+    #[parameterized(input = {"x", "xy", "foo123", "test"})]
+    fn parses_ref(input: &str) -> Result<()> {
+        let parsed = FslParser::parse(Rule::reference, input)
+            .expect("Failed to parse FSL syntax");
+        assert_that!(parsed.as_str(), is(equal_to(input)));
+        Ok(())
+    }
+
+    // @todo #5:30min Prohibit usage of upper-case letters in reference, i.e. X, Y, Z.
+    //  We should prohibit usage of upper-case letters in reference name. Only
+    //  lower-case letters should be allowed.
+    #[should_panic(expected = "Failed to parse reference")]
+    #[parameterized(
+        input = {
+            "_",
+            "_test",
+            "@",
+            "."
+        }
+    )]
+    fn panics_on_invalid_ref(input: &str) {
+        FslParser::parse(Rule::reference, input).expect("Failed to parse reference");
     }
 }

--- a/src/program.pest
+++ b/src/program.pest
@@ -21,9 +21,23 @@
 // SOFTWARE.
 
 /// Program.
+program = { me ~ NEWLINE ~ (command ~ NEWLINE)* }
+command = { CREATION ~ object }
+object = { oid ~ WHITE_SPACE ~ (attributes ~ WHITE_SPACE)? ~ new? }
+oid = { char+ }
+// allow only me/+
+attributes = { char+ }
+new = { ASSIGNMENT ~ WHITE_SPACE ~ reference}
+reference = { char+ }
 me = { (ME ~ SEMICOLON ~ WHITE_SPACE ~ login) }
 login = {"@" ~ char+}
 char = { ASCII_ALPHANUMERIC | "." | "_" | "/" }
 
+// me: @jeff
+// +repo me/foo > foo
+// +repo me/bar
+// +issue "this is testing" +label "bug" -> foo
+ASSIGNMENT = {">"}
+CREATION = {"+"}
 ME = {"me"}
 SEMICOLON = {":"}

--- a/src/program.pest
+++ b/src/program.pest
@@ -25,19 +25,15 @@ program = { (me ~ NEWLINE) ~ (command ~ NEWLINE)* }
 command = { CREATION ~ object }
 object = { oid ~ WHITE_SPACE ~ (attributes ~ WHITE_SPACE)? ~ new? }
 oid = { char+ }
-// allow only me/+
-attributes = { char+ }
+attributes = { (ME ~ AT ~ char+) | char+ }
 new = { ASSIGNMENT ~ WHITE_SPACE ~ reference}
 reference = { char+ }
 me = { (ME ~ SEMICOLON ~ WHITE_SPACE ~ login) }
-login = {"@" ~ ASCII_ALPHANUMERIC+}
-char = { ASCII_ALPHANUMERIC | "." | "_" | "/" }
+login = {"@" ~ char+}
+char = {ASCII_ALPHANUMERIC}
 
-// me: @jeff
-// +repo me/foo > foo
-// +repo me/bar
-// +issue "this is testing" +label "bug" -> foo
 ASSIGNMENT = {">"}
 CREATION = {"+"}
 ME = {"me"}
+AT = {"/"}
 SEMICOLON = {":"}

--- a/src/program.pest
+++ b/src/program.pest
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 /// Program.
-program = { me ~ NEWLINE ~ (command ~ NEWLINE)* }
+program = { (me ~ NEWLINE) ~ (command ~ NEWLINE)* }
 command = { CREATION ~ object }
 object = { oid ~ WHITE_SPACE ~ (attributes ~ WHITE_SPACE)? ~ new? }
 oid = { char+ }
@@ -30,7 +30,7 @@ attributes = { char+ }
 new = { ASSIGNMENT ~ WHITE_SPACE ~ reference}
 reference = { char+ }
 me = { (ME ~ SEMICOLON ~ WHITE_SPACE ~ login) }
-login = {"@" ~ char+}
+login = {"@" ~ ASCII_ALPHANUMERIC+}
 char = { ASCII_ALPHANUMERIC | "." | "_" | "/" }
 
 // me: @jeff

--- a/src/program.pest
+++ b/src/program.pest
@@ -30,7 +30,7 @@ new = { ASSIGNMENT ~ WHITE_SPACE ~ reference}
 reference = { char+ }
 me = { (ME ~ SEMICOLON ~ WHITE_SPACE ~ login) }
 login = {"@" ~ char+}
-char = {ASCII_ALPHANUMERIC}
+char = { ASCII_ALPHANUMERIC }
 
 ASSIGNMENT = {">"}
 CREATION = {"+"}


### PR DESCRIPTION
closes #5 
History:
- **feat(#5): parses_command**
- **feat(#5): parses_object**
- **feat(#5): parametrized, parses into**
- **feat(#5): parametrized panic**
- **feat(#5): valid login name**
- **feat(#5): parses_object_without_attributes**
- **feat(#5): layout**
- **feat(#5): spaces**
- **feat(#5): parses_ref, panics_on_invalid_ref**
- **feat(#5): puzzles**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new parsing rules in the `src/program.pest` file for handling FSL (Function Specification Language) programs and updates the tests in `src/parser/fsl_parser.rs` to validate these rules. It also adds a new dependency on `parameterized`.

### Detailed summary
- Added `parameterized` dependency in `Cargo.toml`.
- Introduced new parsing rules in `src/program.pest`:
  - `program`, `command`, `object`, `oid`, `attributes`, `new`, `reference`, `ASSIGNMENT`, `CREATION`, `ME`, `AT`, and `SEMICOLON`.
- Updated test function names and added tests in `src/parser/fsl_parser.rs`:
  - `parses_program`
  - `parses_me`
  - `parses_login`
  - `panics_on_invalid_login`
  - `parses_command`
  - `parses_object`
  - `parses_object_without_attributes`
  - `parses_new`
  - `parses_ref`
  - `panics_on_invalid_ref`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->