### PR TITLE
feat(#8): char is LOWERCASE_LETTER

### DIFF
--- a/src/parser/fsl_parser.rs
+++ b/src/parser/fsl_parser.rs
@@ -116,7 +116,7 @@ mod tests {
         Ok(())
     }
 
-    #[parameterized(input = {"x", "xy", "foo123", "test"})]
+    #[parameterized(input = {"x", "xy", "foo", "test"})]
     fn parses_ref(input: &str) -> Result<()> {
         let parsed = FslParser::parse(Rule::reference, input)
             .expect("Failed to parse FSL syntax");
@@ -124,17 +124,18 @@ mod tests {
         Ok(())
     }
 
-    // @todo #5:30min Prohibit usage of upper-case letters in reference, i.e. X, Y, Z.
-    //  We should prohibit usage of upper-case letters in reference name. Only
-    //  lower-case letters should be allowed.
     #[should_panic(expected = "Failed to parse reference")]
     #[parameterized(
         input = {
             "_",
             "_test",
             "@",
+            "!",
+            "!bar",
             ".",
-            "/t"
+            "/t",
+            "X",
+            "XYZ"
         }
     )]
     fn panics_on_invalid_ref(input: &str) {

--- a/src/program.pest
+++ b/src/program.pest
@@ -29,8 +29,8 @@ attributes = { (ME ~ AT ~ char+) | char+ }
 new = { ASSIGNMENT ~ WHITE_SPACE ~ reference}
 reference = { char+ }
 me = { (ME ~ SEMICOLON ~ WHITE_SPACE ~ login) }
-login = {"@" ~ char+}
-char = { ASCII_ALPHANUMERIC }
+login = { "@" ~ char+ }
+char = { LOWERCASE_LETTER }
 
 ASSIGNMENT = {">"}
 CREATION = {"+"}


### PR DESCRIPTION
closes #8 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifications to the parsing rules in `src/program.pest` and `src/parser/fsl_parser.rs`, specifically adjusting the definitions for `login` and `char`, as well as updating test cases to reflect new valid and invalid inputs.

### Detailed summary
- In `src/program.pest`:
  - Changed `-login` to `+login` definition.
  - Updated `-char` to `+char` to only allow `LOWERCASE_LETTER`.
- In `src/parser/fsl_parser.rs`:
  - Updated test cases to change valid input from `"foo123"` to `"foo"` and added invalid inputs `"X"` and `"XYZ"`.
- Removed comments regarding prohibiting upper-case letters in references.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->