### PR TITLE
feat(#10): rename to transpiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Here, we logged in as `@jeff` fake GitHub user, created two repositories:
 And then compile it:
 
 ```rust
-use fsl::compiler::fsl_compiler::Fslc;
+use fsl::transpiler::fsl_transpiler::Fslt;
 use std::path::Path;
 
-let output = Fslc::file(Path::new("init.fsl")).out();
+let output = Fslt::file(Path::new("init.fsl")).out();
 // output...
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ FSL.
 #[allow(unused_imports)]
 #[macro_use]
 extern crate hamcrest;
-/// FSL Transpiler.
-pub mod transpiler;
 /// FSL Parser.
 pub mod parser;
+/// FSL Transpiler.
+pub mod transpiler;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ FSL.
 #[allow(unused_imports)]
 #[macro_use]
 extern crate hamcrest;
-/// FSL Compiler.
-pub mod compiler;
+/// FSL Transpiler.
+pub mod transpiler;
 /// FSL Parser.
 pub mod parser;

--- a/src/transpiler/fsl_transpiler.rs
+++ b/src/transpiler/fsl_transpiler.rs
@@ -24,30 +24,30 @@ use log::info;
 use std::fs;
 use std::path::Path;
 
-/// FSL compiler.
+/// FSL transpiler.
 /// ```
-/// use fsl::compiler::fsl_compiler::Fslc;
-/// let output = Fslc::program(String::from("me: @jeff\n +repo me/foo")).out();
+/// use fsl::transpiler::fsl_transpiler::Fslt;
+/// let output = Fslt::program(String::from("me: @jeff\n +repo me/foo")).out();
 /// ```
-pub struct Fslc {
-    /// Program to compile.
+pub struct Fslt {
+    /// Program to transpiler.
     pub program: String,
     /// Parser.
     pub parser: FslParser,
 }
 
-impl Fslc {
-    /// New compiler for program.
-    pub fn program(program: String) -> Fslc {
-        Fslc {
+impl Fslt {
+    /// New transpiler for program.
+    pub fn program(program: String) -> Fslt {
+        Fslt {
             program,
             parser: FslParser {},
         }
     }
 
-    /// New compiler for program in file.
-    pub fn file(path: &Path) -> Fslc {
-        Fslc {
+    /// New transpiler for program in file.
+    pub fn file(path: &Path) -> Fslt {
+        Fslt {
             program: fs::read_to_string(path).unwrap_or_else(|_| {
                 panic!("Failed to read path: {}", path.display())
             }),
@@ -63,16 +63,16 @@ impl Fslc {
 
 #[cfg(test)]
 mod tests {
-    use crate::compiler::fsl_compiler::Fslc;
+    use crate::transpiler::fsl_transpiler::Fslt;
     use anyhow::Result;
     use log::Level;
     use std::path::Path;
     extern crate testing_logger;
 
     #[test]
-    fn compiles_program_as_string() -> Result<()> {
+    fn transpiles_program_as_string() -> Result<()> {
         testing_logger::setup();
-        Fslc::program(String::from("me: @jeff +repo me/foo")).out();
+        Fslt::program(String::from("me: @jeff +repo me/foo")).out();
         testing_logger::validate(|logs| {
             assert_eq!(logs.len(), 1);
             assert_eq!(logs[0].body, "Done!");
@@ -82,9 +82,9 @@ mod tests {
     }
 
     #[test]
-    fn compiles_program_from_file() -> Result<()> {
+    fn transpiles_program_from_file() -> Result<()> {
         testing_logger::setup();
-        Fslc::file(Path::new("resources/programs/me.fsl")).out();
+        Fslt::file(Path::new("resources/programs/me.fsl")).out();
         testing_logger::validate(|logs| {
             assert_eq!(logs.len(), 1);
             assert_eq!(logs[0].body, "Done!");

--- a/src/transpiler/mod.rs
+++ b/src/transpiler/mod.rs
@@ -19,5 +19,5 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-/// FSL Compiler.
-pub mod fsl_compiler;
+/// FSL to FakeHub types (Rust) transpiler.
+pub mod fsl_transpiler;


### PR DESCRIPTION
In this pull I've renamed `Fslc` compiler to `Fslt` transpiler (FSL to FakeHub Rust types), you can read [this](https://www.tutorchase.com/answers/a-level/computer-science/explain-the-difference-between-a-transpiler-and-a-compiler) about what is the difference between these terms.

ref: #10 
History:
- **feat(#10): transpiler**
- **feat(#10): docs**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming and refactoring the `FSL Compiler` module to `FSL Transpiler`, along with updating related structures and functions to reflect this change.

### Detailed summary
- Removed the `compiler` module and added a `transpiler` module in `src/lib.rs`.
- Updated usage from `Fslc` to `Fslt` in `README.md` and test functions.
- Renamed `Fslc` struct to `Fslt` in `src/transpiler/fsl_transpiler.rs`.
- Changed method names and comments to reflect the transpiler functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->