### PR TITLE
feat(#7): sample_program in parametrized tests

### DIFF
--- a/resources/programs/plusrepo-plusbar.fsl
+++ b/resources/programs/plusrepo-plusbar.fsl
@@ -1,0 +1,3 @@
+me: @jeff
++repo me/foo > x
++repo me/bar > y

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,4 +29,5 @@ extern crate hamcrest;
 pub mod compiler;
 /// FSL Parser.
 pub mod parser;
-mod sample_program;
+/// Program.
+pub mod sample_program;

--- a/src/parser/fsl_parser.rs
+++ b/src/parser/fsl_parser.rs
@@ -29,28 +29,30 @@ pub struct FslParser {}
 #[cfg(test)]
 mod tests {
     use crate::parser::fsl_parser::{FslParser, Rule};
+    #[allow(unused_imports)]
+    // required for usage in #parametrized.
+    use crate::sample_program::sample_program;
     use anyhow::Result;
     use hamcrest::{equal_to, is, HamcrestMatcher};
     use parameterized::parameterized;
     use pest::Parser;
 
-    #[test]
-    // @todo #5:35min Supply FSL programs from input files.
-    //  Instead of supplying FSL programs as strings here, we should read them
-    //  from `resources/snippets/`.
-    fn parses_program() -> Result<()> {
-        let parsed = FslParser::parse(
-            Rule::program,
-            "me: @jeff\n+repo me/foo > x\n+repo me/bar > y\n",
-        )
-        .expect("Failed to parse FSL syntax")
-        .next()
-        .expect("Failed to get pair");
+    #[parameterized(
+        program = {
+            &sample_program("me.fsl"),
+            &sample_program("plusrepo-plusbar.fsl")
+        }
+      )
+    ]
+    fn parses_program(program: &str) -> Result<()> {
+        let parsed = FslParser::parse(Rule::program, program)
+            .expect("Failed to parse FSL syntax")
+            .next()
+            .expect("Failed to get pair");
         let pairs = parsed.into_inner().as_str();
-        assert_that!(
-            pairs,
-            is(equal_to("me: @jeff\n+repo me/foo > x\n+repo me/bar > y"))
-        );
+        let mut trimmed = program.to_string();
+        trimmed.pop().expect("Failed to remove last character");
+        assert_that!(String::from(pairs), is(equal_to(trimmed)));
         Ok(())
     }
 

--- a/src/sample_program.rs
+++ b/src/sample_program.rs
@@ -19,14 +19,28 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-/*!
-FSL.
- */
-#[allow(unused_imports)]
-#[macro_use]
-extern crate hamcrest;
-/// FSL Compiler.
-pub mod compiler;
-/// FSL Parser.
-pub mod parser;
-mod sample_program;
+use std::fs;
+use std::path::Path;
+
+/// Sample program from file.
+/// `filename` File name.
+pub fn sample_program(filename: &str) -> String {
+    fs::read_to_string(Path::new(&format!("resources/programs/{}", filename)))
+        .expect("Failed to read content from file")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::sample_program::sample_program;
+    use anyhow::Result;
+    use hamcrest::{equal_to, is, HamcrestMatcher};
+
+    #[test]
+    fn reads_sample() -> Result<()> {
+        assert_that!(
+            sample_program("me.fsl").as_str(),
+            is(equal_to("me: @jeff\n"))
+        );
+        Ok(())
+    }
+}

--- a/src/sample_program.rs
+++ b/src/sample_program.rs
@@ -24,6 +24,11 @@ use std::path::Path;
 
 /// Sample program from file.
 /// `filename` File name.
+/// ```
+/// use hamcrest::{assert_that, equal_to, is, HamcrestMatcher};
+/// use fsl::sample_program::sample_program;
+/// assert_that!(sample_program("me.fsl").as_str(), is(equal_to("me: @jeff\n")))
+/// ```
 pub fn sample_program(filename: &str) -> String {
     fs::read_to_string(Path::new(&format!("resources/programs/{}", filename)))
         .expect("Failed to read content from file")


### PR DESCRIPTION
In this pull I've implemented `sample_program(filename)` function that returns program from `resources/programs`.

closes #7
History:
- **feat(#7): sample_program**
- **feat(#7): parametrized**
