### PR TITLE
feat(#28): invalid_application_ref

### DIFF
--- a/resources/programs/errors/duplicate-invalid.fsl
+++ b/resources/programs/errors/duplicate-invalid.fsl
@@ -1,0 +1,4 @@
+me: @jeff
++repo me/foo > x
++repo me/bar > x
++repo me/test -> z

--- a/src/transpiler/errors/err_ast.rs
+++ b/src/transpiler/errors/err_ast.rs
@@ -106,4 +106,16 @@ mod tests {
         assert_that!(errors.is_empty(), is(equal_to(false)));
         Ok(())
     }
+
+    #[test]
+    fn composes_errors() -> Result<()> {
+        let transpiler =
+            Fslt::program(sample_program("errors/duplicate-invalid.fsl"));
+        let decorated = ErrAst::default(transpiler).decorate();
+        let errors = decorated["errors"]
+            .as_array()
+            .expect("failed to get errors");
+        assert_that!(errors.len(), is(equal_to(2)));
+        Ok(())
+    }
 }

--- a/src/transpiler/errors/err_ast.rs
+++ b/src/transpiler/errors/err_ast.rs
@@ -74,6 +74,7 @@ mod tests {
     use crate::sample_program::sample_program;
     use crate::transpiler::errors::duplicate_refs::DuplicateRefs;
     use crate::transpiler::errors::err_ast::ErrAst;
+    use crate::transpiler::errors::invalid_application_ref::InvalidApplicationRef;
     use crate::transpiler::fsl_transpiler::Fslt;
     use anyhow::Result;
     use hamcrest::{equal_to, is, HamcrestMatcher};
@@ -84,6 +85,20 @@ mod tests {
             Fslt::program(sample_program("errors/duplicate-refs.fsl"));
         let decorated =
             ErrAst::new(transpiler, vec![Box::new(DuplicateRefs {})])
+                .decorate();
+        let errors = decorated["errors"]
+            .as_array()
+            .expect("failed to get errors");
+        assert_that!(errors.is_empty(), is(equal_to(false)));
+        Ok(())
+    }
+
+    #[test]
+    fn adds_error_for_invalid_application_ref() -> Result<()> {
+        let transpiler =
+            Fslt::program(sample_program("errors/invalid-application-ref.fsl"));
+        let decorated =
+            ErrAst::new(transpiler, vec![Box::new(InvalidApplicationRef {})])
                 .decorate();
         let errors = decorated["errors"]
             .as_array()

--- a/src/transpiler/errors/err_ast.rs
+++ b/src/transpiler/errors/err_ast.rs
@@ -21,6 +21,7 @@
 // SOFTWARE.
 use crate::transpiler::errors::check::Check;
 use crate::transpiler::errors::duplicate_refs::DuplicateRefs;
+use crate::transpiler::errors::invalid_application_ref::InvalidApplicationRef;
 use crate::transpiler::fsl_transpiler::Fslt;
 use serde_json::{json, Value};
 
@@ -37,7 +38,10 @@ impl ErrAst {
     pub fn default(base: Fslt) -> ErrAst {
         ErrAst {
             base,
-            checks: vec![Box::new(DuplicateRefs {})],
+            checks: vec![
+                Box::new(DuplicateRefs {}),
+                Box::new(InvalidApplicationRef {}),
+            ],
         }
     }
 

--- a/src/transpiler/errors/invalid_application_ref.rs
+++ b/src/transpiler/errors/invalid_application_ref.rs
@@ -1,0 +1,71 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2024 Aliaksei Bialiauski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+use crate::transpiler::errors::check::Check;
+use serde_json::Value;
+
+/// Invalid application ref check.
+pub struct InvalidApplicationRef {}
+
+impl Check for InvalidApplicationRef {
+    fn inspect(&self, ast: &Value) -> Vec<String> {
+        let mut errors = Vec::new();
+        let commands = ast
+            .get("program")
+            .and_then(|p| p.get("commands"))
+            .and_then(|c| c.as_array())
+            .expect("failed to get commands");
+        let refs: Vec<&Value> =
+            commands.iter().filter_map(|c| c.get("ref")).collect();
+        let applications: Vec<&Value> = commands
+            .iter()
+            .filter_map(|c| c.get("application"))
+            .collect();
+        applications.iter().for_each(|a| {
+            if !refs.contains(a) {
+                errors.push(format!(
+                    "Invalid application -> {}; Ref `{}` does not exist ",
+                    a, a
+                ));
+            }
+        });
+        errors
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::sample_program::sample_program;
+    use crate::transpiler::errors::check::Check;
+    use crate::transpiler::errors::invalid_application_ref::InvalidApplicationRef;
+    use crate::transpiler::fsl_transpiler::Fslt;
+    use anyhow::Result;
+    use hamcrest::{equal_to, is, HamcrestMatcher};
+
+    #[test]
+    fn adds_errors_for_invalid_application_ref() -> Result<()> {
+        let transpiler =
+            Fslt::program(sample_program("errors/invalid-application-ref.fsl"));
+        let errors = InvalidApplicationRef {}.inspect(&transpiler.out());
+        assert_that!(errors.is_empty(), is(equal_to(false)));
+        Ok(())
+    }
+}

--- a/src/transpiler/errors/invalid_application_ref.rs
+++ b/src/transpiler/errors/invalid_application_ref.rs
@@ -42,7 +42,7 @@ impl Check for InvalidApplicationRef {
         applications.iter().for_each(|a| {
             if !refs.contains(a) {
                 errors.push(format!(
-                    "Invalid application -> {}; Ref `{}` does not exist ",
+                    "Invalid application -> {}; Ref `{}` does not exist",
                     a, a
                 ));
             }
@@ -65,7 +65,12 @@ mod tests {
         let transpiler =
             Fslt::program(sample_program("errors/invalid-application-ref.fsl"));
         let errors = InvalidApplicationRef {}.inspect(&transpiler.out());
-        assert_that!(errors.is_empty(), is(equal_to(false)));
+        assert_that!(
+            errors.first().expect("failed to get first error"),
+            is(equal_to(
+                "Invalid application -> \"x\"; Ref `\"x\"` does not exist"
+            ))
+        );
         Ok(())
     }
 }

--- a/src/transpiler/errors/mod.rs
+++ b/src/transpiler/errors/mod.rs
@@ -25,3 +25,5 @@ pub mod check;
 pub mod duplicate_refs;
 /// Error AST decoration.
 pub mod err_ast;
+/// Invalid application ref check.
+pub mod invalid_application_ref;


### PR DESCRIPTION
In this pull I've implemented AST check for invalid application ref.

closes #28 
History:
- **feat(#28): invalid_application_ref**
- **feat(#28): test in err_ast**
- **feat(#28): compose test**
- **feat(#28): test message**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces an `InvalidApplicationRef` error check to enhance error handling in the transpiler. It integrates this new check into the existing error handling system and adds related tests.

### Detailed summary
- Added a new module `invalid_application_ref` for checking invalid application references.
- Updated `ErrAst` to include `InvalidApplicationRef` in its error checks.
- Created tests for `InvalidApplicationRef` to validate its functionality.
- Added a test for composing errors in `ErrAst`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->