### PR TITLE
feat(#25): license rule

### DIFF
--- a/resources/programs/with-license.fsl
+++ b/resources/programs/with-license.fsl
@@ -1,0 +1,9 @@
+# MIT LICENSE
+# Testing the license rule.
+# Even more license text.
+me: @jeff
+# Create foo repo, assign to `x`.
++repo me/foo > x
+# Create bar repo, assign to `y`.
+# Here, `y` is a new variable.
++repo me/bar > y

--- a/src/parser/fsl_parser.rs
+++ b/src/parser/fsl_parser.rs
@@ -189,4 +189,13 @@ mod tests {
         assert_that!(pairs.as_str().len(), is(equal_to(143)));
         Ok(())
     }
+
+    #[test]
+    fn parses_program_with_license() -> Result<()> {
+        let program = &sample_program("with-license.fsl");
+        let pairs = FslParser::parse(Rule::program, program)
+            .expect("failed to parse program with license");
+        assert_that!(pairs.as_str().len(), is(equal_to(211)));
+        Ok(())
+    }
 }

--- a/src/program.pest
+++ b/src/program.pest
@@ -21,7 +21,8 @@
 // SOFTWARE.
 
 /// Program.
-program = { (me ~ NEWLINE ~ comment*) ~ (command ~ NEWLINE)* }
+program = { license? ~ (me ~ NEWLINE ~ comment*) ~ (command ~ NEWLINE)* }
+license = { comment* }
 command = { comment* ~ CREATION ~ object }
 object = { oid ~ WHITE_SPACE ~ (attributes ~ WHITE_SPACE)? ~ (new | application)? }
 oid = { char+ }


### PR DESCRIPTION
In this pull I've added `license` rule into program grammar in order to support license at the top of file.

closes #25

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for license comments in the program structure and adds a test to ensure proper parsing of files that include a license.

### Detailed summary
- Added a license section to the `program` grammar in `src/program.pest`.
- Created a new `license` rule to capture comments as licenses.
- Implemented a test function `parses_program_with_license` in `src/parser/fsl_parser.rs` to verify parsing of `with-license.fsl`.
- Updated `resources/programs/with-license.fsl` to include a sample license text.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->